### PR TITLE
bump murmur3 to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/nlopes/slack v0.6.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/twmb/murmur3 v1.0.0
+	github.com/twmb/murmur3 v1.1.1
 	github.com/viant/afs v0.12.0
 	github.com/viant/afsc v0.12.0
 	github.com/viant/assertly v0.5.1


### PR DESCRIPTION
murmur3 included unsafe code; go1.14 has a -d=checkptr flag that checks
some uses of unsafe code. Turns out, the original usage of murmur3 was
unsafe due to alignment issues.

This does not affect the murmur128 assembly code because unaligned reads
on amd64 are safe (although slower, but we don't usually expect the hash
to have unaligned input).

This bumps the dep to pull in the fixes.